### PR TITLE
SslCertificateDirectory generalized

### DIFF
--- a/ChiaRPC.Net/Clients/ChiaRPCOptions.cs
+++ b/ChiaRPC.Net/Clients/ChiaRPCOptions.cs
@@ -14,14 +14,7 @@ namespace ChiaRPC.Clients
 
         public ChiaRPCOptions()
         {
-            if (OperatingSystem.IsWindows())
-            {
-                SslCertificateDirectory = "%userprofile%\\.chia\\mainnet\\config\\ssl";
-            }
-            if (OperatingSystem.IsLinux())
-            {
-                SslCertificateDirectory = "/root/.chia/mainnet/config/ssl";
-            }
+            SslCertificateDirectory = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile) + "/.chia/mainnet/config/ssl";
         }
     }
 }


### PR DESCRIPTION
On Windows `%userprofile%` is only interpreted in a few cases, depending on the environment it runs in. This does not include Visual Studio or PowerShell for example.

Using `Environment.GetFolderPath(Environment.SpecialFolder.UserProfile)` works always for Windows, Linux and Mac and C# supports forward slash for Windows.

Note: Linux was hardcoded to the root user before. Now it uses the current user.