### PR TITLE
Fixing SendTransaction and other RPC Calls that require non-string types

### DIFF
--- a/ChiaRPC.Net/Clients/Wallet/WalletRPCClient.cs
+++ b/ChiaRPC.Net/Clients/Wallet/WalletRPCClient.cs
@@ -86,11 +86,11 @@ namespace ChiaRPC.Clients
         /// <returns>A record representing the transaction. The transaction id is stored in the name property.</returns>
         public async Task<TransactionRecord> SendTransactionAsync(uint walletId, ulong amount, ulong fee, string targetAddress)
         {
-            var result = await PostAsync<TransactionResult>(WalletRoutes.SendTransaction(), new Dictionary<string, string>()
+            var result = await PostAsyncRaw<TransactionResult>(WalletRoutes.SendTransaction(), new Dictionary<string, object>()
             {
                 ["wallet_id"] = $"{walletId}",
-                ["amount"] = $"{amount}",
-                ["fee"] = $"{fee}",
+                ["amount"] = amount,
+                ["fee"] = fee,
                 ["address"] = targetAddress,
             });
 

--- a/ChiaRPC.Net/Models/Wallet/TransactionRecord.cs
+++ b/ChiaRPC.Net/Models/Wallet/TransactionRecord.cs
@@ -32,7 +32,7 @@ namespace ChiaRPC.Models
         [JsonPropertyName("additions")]
         public Coin[] Additions { get; init; }
 
-        [JsonPropertyName("additions")]
+        [JsonPropertyName("removals")]
         public Coin[] Removals { get; init; }
 
         [JsonPropertyName("wallet_id")]

--- a/ChiaRPC.Net/Results/Wallet/TransactionResult.cs
+++ b/ChiaRPC.Net/Results/Wallet/TransactionResult.cs
@@ -1,4 +1,5 @@
 ﻿using ChiaRPC.Models;
+using ChiaRPC.Parsers;
 using System.Text.Json.Serialization;
 
 namespace ChiaRPC.Results
@@ -9,6 +10,7 @@ namespace ChiaRPC.Results
         public TransactionRecord Transaction { get; init; }
 
         [JsonPropertyName("transaction_id")]
+        [JsonConverter(typeof(HexBytesConverter))]
         public HexBytes TransactionId { get; init; }
 
         public TransactionResult()


### PR DESCRIPTION
- Using PostAsyncRaw in send_transaction as chia [requires amount and fee to be of int type.](https://github.com/Chia-Network/chia-blockchain/blob/main/chia/rpc/wallet_rpc_api.py#L705)

- Fixed Property Removals of TransactionRecord being bound to json field additions.

- Fixed TransactionResult transaction_id was using the wrong parser.